### PR TITLE
Add ability to specify filters as being Must, MustNot, or Should clauses.

### DIFF
--- a/src/main/java/com/scaleset/search/Filter.java
+++ b/src/main/java/com/scaleset/search/Filter.java
@@ -8,19 +8,29 @@ import com.scaleset.utils.Extensible;
 
 import java.util.Map;
 
-@JsonPropertyOrder({"type", "name"})
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanClause.Occur;
+
+@JsonPropertyOrder({"type", "name", "clause"})
 public class Filter extends Extensible {
 
     private String name;
     private String type;
+    private BooleanClause.Occur clause = Occur.MUST;
 
-    public Filter() {
+	public Filter() {
         super(new Coerce(new ObjectMapper().registerModule(new GeoJsonModule())));
     }
 
     public Filter(String name, String type) {
         this.name = name;
         this.type = type;
+    }
+    
+    public Filter(String name, String type, Occur clause) {
+        this.name = name;
+        this.type = type;
+        this.clause = clause;
     }
 
     public Filter(String name, String type, Map<String, Object> properties) {
@@ -47,4 +57,12 @@ public class Filter extends Extensible {
     public void setType(String type) {
         this.type = type;
     }
+    
+    public BooleanClause.Occur getClause() {
+		return clause;
+	}
+
+	public void setClause(BooleanClause.Occur clause) {
+		this.clause = clause;
+	}
 }

--- a/src/main/java/com/scaleset/search/Filter.java
+++ b/src/main/java/com/scaleset/search/Filter.java
@@ -8,15 +8,13 @@ import com.scaleset.utils.Extensible;
 
 import java.util.Map;
 
-import org.apache.lucene.search.BooleanClause;
-import org.apache.lucene.search.BooleanClause.Occur;
-
 @JsonPropertyOrder({"type", "name", "clause"})
 public class Filter extends Extensible {
 
     private String name;
     private String type;
-    private BooleanClause.Occur clause = Occur.MUST;
+    public enum Occur {MUST, MUST_NOT, SHOULD};
+    private Occur clause = Occur.MUST;
 
 	public Filter() {
         super(new Coerce(new ObjectMapper().registerModule(new GeoJsonModule())));
@@ -58,11 +56,11 @@ public class Filter extends Extensible {
         this.type = type;
     }
     
-    public BooleanClause.Occur getClause() {
+    public Occur getClause() {
 		return clause;
 	}
 
-	public void setClause(BooleanClause.Occur clause) {
+	public void setClause(Occur clause) {
 		this.clause = clause;
 	}
 }

--- a/src/main/java/com/scaleset/search/es/DefaultQueryConverter.java
+++ b/src/main/java/com/scaleset/search/es/DefaultQueryConverter.java
@@ -77,7 +77,17 @@ public class DefaultQueryConverter implements QueryConverter {
             for (Filter filter : filters.values()) {
                 FilterBuilder filterBuilder = converterFilter(filter);
                 if (filterBuilder != null) {
-                    boolFilter.must(filterBuilder);
+                	switch (filter.getClause()) {
+                	case SHOULD:
+                		boolFilter.should(filterBuilder);
+                		break;
+                	case MUST_NOT:
+                		boolFilter.mustNot(filterBuilder);
+                		break;
+                	case MUST:
+                	default :
+                		boolFilter.must(filterBuilder);                	
+                	}
                 }
             }
         }


### PR DESCRIPTION
Previously all queries sent to Elasticsearch where implicitly Must clauses, this change adds the ability to make them Should or MustNot clauses.